### PR TITLE
Fix bug where item and collection id was wrongly retrieved.

### DIFF
--- a/stac_fastapi/elasticsearch/transactions.py
+++ b/stac_fastapi/elasticsearch/transactions.py
@@ -70,7 +70,7 @@ class TransactionsClient(BaseTransactionsClient):
         request: Request = kwargs['request']
         base_url = str(request.base_url)
         collection_id = str(request.path_params.get('collection_id'))
-        item_id = str(request.path_params.get('item_id'))
+        item_id = str(item.get('id'))
 
         try:
             ElasticsearchCollection.get(id=collection_id)
@@ -157,7 +157,7 @@ class TransactionsClient(BaseTransactionsClient):
         """
         request: Request = kwargs['request']
         base_url = str(request.base_url)
-        collection_id = str(request.path_params.get('collection_id'))
+        collection_id = str(collection.get('id'))
 
         try:
             collection_db = ElasticsearchCollection.get(id=collection_id)


### PR DESCRIPTION
I realised the update method URL pattern just ended in `{collection_id}/items/` and `collections/` so it is unable to get `item_id` and `collection_id` from the starlette request. Retrieves it from the body now 👍  