### PR TITLE
PySTAC compliance

### DIFF
--- a/stac_fastapi/elasticsearch/models/database.py
+++ b/stac_fastapi/elasticsearch/models/database.py
@@ -158,11 +158,14 @@ class ElasticsearchItem(Document):
         """
 
         try:
-            coordinates = rgetattr(self, 'bbox.coordinates')
+            coordinates = rgetattr(self, 'spatial.bbox.coordinates')
         except AttributeError:
             return
 
         return Coordinates.from_geojson(coordinates).to_wgs84()
+
+    def get_geometry(self):
+        ...
 
     def get_collection_id(self) -> str:
         """
@@ -223,7 +226,7 @@ class ElasticsearchAsset(Document):
         except AttributeError:
             return
 
-    def get_role(self) -> Optional[List]:
+    def get_roles(self) -> Optional[List]:
 
         try:
             roles = getattr(self, 'categories')

--- a/stac_fastapi/elasticsearch/models/database.py
+++ b/stac_fastapi/elasticsearch/models/database.py
@@ -148,6 +148,11 @@ class ElasticsearchItem(Document):
         except AttributeError:
             return {}
 
+        if not hasattr(self, 'datetime'):
+            if "start_datetime" not in properties or "end_datetime" not in properties:
+                properties["start_datetime"] = None
+                properties["end_datetime"] = None
+
         return properties.to_dict()
 
     def get_bbox(self):
@@ -293,7 +298,7 @@ class ElasticsearchAsset(Document):
             href=self.get_url(),
             type=getattr(self, 'magic_number', None),
             title=getattr(self, 'filename', None),
-            roles=self.get_role()
+            roles=self.get_roles()
         )
 
         return asset

--- a/stac_fastapi/elasticsearch/models/database.py
+++ b/stac_fastapi/elasticsearch/models/database.py
@@ -247,7 +247,7 @@ class ElasticsearchAsset(Document):
         Convert the path into a url where you can access the asset
         """
         if getattr(self, 'media_type', 'POSIX') == 'POSIX':
-            return f'{settings.dap_url}{self.location}'
+            return f'{settings.posix_download_url}{self.location}'
         else:
             return self.href
     

--- a/stac_fastapi/elasticsearch/models/database.py
+++ b/stac_fastapi/elasticsearch/models/database.py
@@ -8,6 +8,8 @@ __copyright__ = 'Copyright 2018 United Kingdom Research and Innovation'
 __license__ = 'BSD - see LICENSE file in top-level package directory'
 __contact__ = 'richard.d.smith@stfc.ac.uk'
 
+from stac_fastapi.elasticsearch.config import settings
+
 from elasticsearch_dsl import Document, InnerDoc, Nested
 from elasticsearch_dsl import DateRange, GeoShape
 from .utils import Coordinates, rgetattr
@@ -244,8 +246,10 @@ class ElasticsearchAsset(Document):
         """
         Convert the path into a url where you can access the asset
         """
-        if getattr(self, 'media_type','POSIX'):
-            return f'https://dap.ceda.ac.uk{self.location}'
+        if getattr(self, 'media_type', 'POSIX') == 'POSIX':
+            return f'{settings.dap_url}{self.location}'
+        else:
+            return self.href
     
     def get_size(self) -> int:
 

--- a/stac_fastapi/elasticsearch/models/serializers.py
+++ b/stac_fastapi/elasticsearch/models/serializers.py
@@ -74,6 +74,7 @@ class ItemSerializer(Serializer):
             id=db_model.meta.id,
             collection=db_model.get_collection_id(),
             bbox=db_model.get_bbox(),
+            geometry=None,
             properties=db_model.get_properties(),
             links=item_links,
             assets=db_model.get_stac_assets()
@@ -203,7 +204,7 @@ class AssetSerializer(Serializer):
             stac_version=getattr(db_model, 'stac_version', STAC_VERSION_DEFAULT),
             stac_extensions=stac_extensions,
             asset_id=db_model.meta.id,
-            role=db_model.get_role(),
+            roles=db_model.get_roles(),
             item=db_model.get_item_id(),
             bbox=db_model.get_bbox(),
             href=db_model.get_url(),
@@ -225,7 +226,7 @@ class AssetSerializer(Serializer):
     ) -> database.ElasticsearchAsset:
         db_item = database.ElasticsearchAsset(
             id=stac_data.get('id'),
-            role=stac_data.get('catagories'),
+            roles=stac_data.get('categories'),
             bbox=stac_data.get('bbox'),
             item_id=stac_data.get('item'),
             location=stac_data.get('location'),

--- a/stac_fastapi/elasticsearch/settings.py.tmpl
+++ b/stac_fastapi/elasticsearch/settings.py.tmpl
@@ -24,4 +24,5 @@ STAC_TITLE='CEDA STAC API'
 
 enable_response_models = True
 openapi_url='/api'
+dap_url = 'https://dap.ceda.ac.uk'
 docs_url='/docs'

--- a/stac_fastapi/elasticsearch/settings.py.tmpl
+++ b/stac_fastapi/elasticsearch/settings.py.tmpl
@@ -24,5 +24,5 @@ STAC_TITLE='CEDA STAC API'
 
 enable_response_models = True
 openapi_url='/api'
-dap_url = 'https://dap.ceda.ac.uk'
+posix_download_url = 'https://dap.ceda.ac.uk'
 docs_url='/docs'

--- a/stac_fastapi/elasticsearch/utils.py
+++ b/stac_fastapi/elasticsearch/utils.py
@@ -132,7 +132,6 @@ def get_queryset(client, table: "Document" , **kwargs) -> Search:
         
             # TODO: add in option for if item specifies start datetime and end datetime instead of datetime
             # should return items which cover a range that the specified datetime falls in
-            
 
     if limit := kwargs.get('limit'):
         if limit > 10000:
@@ -196,6 +195,6 @@ def get_queryset(client, table: "Document" , **kwargs) -> Search:
 
     if client.extension_is_enabled('ContextCollectionExtension'):
         if not collection_ids:
-            qs.aggs.bucket('collections', 'terms', field='collection_id')
+            qs.aggs.bucket('collections', 'terms', field='collection_id.keyword')
 
     return qs


### PR DESCRIPTION
## Fixes:

- bbox co-ordinates are retrieved from `spatial.bbox.coordinates` inline with the rest of the code.
- function name for roles and categories now plural to match the attribute name.
- added `.keyword` to `collections` in the context collections extensions query so ElasticSearch can allow an empty collections field.
- Removed hardcoded dap prefix to `settings.py`
- if statement for media type fixed, no longer perpetually true. 

## Compliance:

- geometry value set to `none`, required value for PySTAC
- `start_datetime` and `end_datetime` set to None if datetime missing.