### PR TITLE
search updates (temporal, bbox, fields)

### DIFF
--- a/stac_fastapi/elasticsearch/app.py
+++ b/stac_fastapi/elasticsearch/app.py
@@ -11,7 +11,7 @@ __contact__ = 'richard.d.smith@stfc.ac.uk'
 from stac_fastapi.api.app import StacApi
 from stac_fastapi.extensions.core import (
     ContextExtension,
-    # FieldsExtension,
+    FieldsExtension,
     # SortExtension,
     FilterExtension,
     PaginationExtension,
@@ -34,7 +34,7 @@ from stac_fastapi_asset_search.client import create_asset_search_get_request_mod
 
 extensions = [
     ContextExtension(),
-    # FieldsExtension(),
+    FieldsExtension(),
     # SortExtension(),
     FilterExtension(client=FiltersClient()),
     FreeTextExtension(),

--- a/stac_fastapi/elasticsearch/utils.py
+++ b/stac_fastapi/elasticsearch/utils.py
@@ -8,7 +8,6 @@ __copyright__ = 'Copyright 2018 United Kingdom Research and Innovation'
 __license__ = 'BSD - see LICENSE file in top-level package directory'
 __contact__ = 'richard.d.smith@stfc.ac.uk'
 
-
 # Python imports
 import collections
 from string import Template
@@ -26,7 +25,7 @@ from pygeofilter_elasticsearch import to_filter
 from fastapi import HTTPException
 
 # Typing imports
-from elasticsearch_dsl.search import Search
+from elasticsearch_dsl.search import Search, Q
 from elasticsearch_dsl.query import QueryString
 from typing import TYPE_CHECKING
 
@@ -55,7 +54,8 @@ def dict_merge(*args, add_keys=True) -> dict:
 
             # This is an existing key with mismatched types
             elif k in rtn_dct and type(v) != type(rtn_dct[k]):
-                raise TypeError(f"Overlapping keys exist with different types: original is {type(rtn_dct[k])}, new value is {type(v)}")
+                raise TypeError(
+                    f"Overlapping keys exist with different types: original is {type(rtn_dct[k])}, new value is {type(v)}")
 
             # Recursive merge the next level
             elif isinstance(rtn_dct[k], dict) and isinstance(merge_dct[k], collections.abc.Mapping):
@@ -72,7 +72,7 @@ def dict_merge(*args, add_keys=True) -> dict:
     return rtn_dct
 
 
-def get_queryset(client, table: "Document" , **kwargs) -> Search:
+def get_queryset(client, table: "Document", **kwargs) -> Search:
     """
     Turn the query into an `elasticsearch_dsl.Search object <https://elasticsearch-dsl.readthedocs.io/en/latest/api.html#search>`_
     :param client: The client class
@@ -83,31 +83,41 @@ def get_queryset(client, table: "Document" , **kwargs) -> Search:
 
     qs = table.search()
 
+    # Query list for must match queries. Equivalent to a logical AND.
+    filter_queries = []
+
+    # Query list for should queries. Equivalent to a logical OR.
+    should_queries = []
+
     if asset_ids := kwargs.get('asset_ids'):
-        qs = qs.filter('terms', asset_id=asset_ids)
+        filter_queries.append(Q('terms', asset_id=asset_ids))
 
     if item_ids := kwargs.get('item_ids'):
-        qs = qs.filter('terms', item_id=item_ids)
+        filter_queries.append(Q('terms', item_id=item_ids))
 
     if collection_ids := kwargs.get('collection_ids'):
-        qs = qs.filter('terms', collection_id=collection_ids)
+        filter_queries.append(Q('terms', collection_id=collection_ids))
 
     if intersects := kwargs.get('intersects'):
-        qs = qs.filter('geo_shape', geometry={
-            'shape': {
-                'type': intersects.get('type'),
-                'coordinates': intersects.get('coordinates')
-            }
-        })
+        filter_queries.append(
+            Q('geo_shape', geometry={
+                'shape': {
+                    'type': intersects.get('type'),
+                    'coordinates': intersects.get('coordinates')
+                }
+            })
+        )
 
     if bbox := kwargs.get('bbox'):
-        qs = qs.filter('geo_shape', spatial_bbox={
-            'shape': {
-                'type': 'envelope',
-                'coordinates': Coordinates.from_wgs84(bbox).to_geojson()
-            }
-        })
-    
+        filter_queries.append(
+            Q('geo_shape', spatial_bbox={
+                'shape': {
+                    'type': 'envelope',
+                    'coordinates': Coordinates.from_wgs84(bbox).to_geojson()
+                }
+            })
+        )
+
     if datetime := kwargs.get('datetime'):
         # currently based on datetime being provided in item
         # if a date range, get start and end datetimes and find any items with dates in this range
@@ -118,20 +128,40 @@ def get_queryset(client, table: "Document" , **kwargs) -> Search:
             start_date = split[0]
             end_date = split[1]
 
-            if start_date != '..':
-                qs = qs.filter('range', properties__datetime={'gte': start_date})
+            # given an end and start date, the start_datetime, end_datetime and datetime should fall within the range.
+            if start_date != '..' and end_date == '..':
+                should_queries.extend([
+                    Q('range', properties__datetime={'gte': start_date}),
+                    Q('range', properties__start_datetime={'gte': start_date})
+                ])
 
-            if end_date != '..':
-                qs = qs.filter('range', properties__datetime={'lte': end_date})
+            elif end_date != '..' and start_date == '..':
+                should_queries.extend([
+                    Q('range', properties__datetime={'lte': end_date}),
+                    Q('range', properties__end_datetime={'lte': end_date})
+                ])
 
-            # TODO: add in option that searches start and end datetime if datetime is null in item
+            elif end_date != '..' and start_date != '..':
+                should_queries.extend([
+                    Q('bool', filter=[
+                        Q('range', properties__datetime={'gte': start_date}),
+                        Q('range', properties__datetime={'lte': end_date})
+                    ]),
+                    Q('bool', filter=[
+                        Q('range', properties__start_datetime={'gte': start_date}),
+                        Q('range', properties__end_datetime={'lte': end_date})
+                    ])
+                ])
 
         else:
-
-            qs = qs.filter('match', properties__datetime=kwargs.get('datetime'))
-        
-            # TODO: add in option for if item specifies start datetime and end datetime instead of datetime
-            # should return items which cover a range that the specified datetime falls in
+            # Given a single datetime, datetime should match properties.datetime OR is within start AND end datetime
+            should_queries.extend([
+                Q('match', properties__datetime=kwargs.get('datetime')),
+                Q('bool', filter=[
+                    Q('range', properties__start_datetime={'lte': kwargs.get('datetime')}),
+                    Q('range', properties__end_datetime={'gte': kwargs.get('datetime')})
+                ])
+            ])
 
     if limit := kwargs.get('limit'):
         if limit > 10000:
@@ -147,7 +177,7 @@ def get_queryset(client, table: "Document" , **kwargs) -> Search:
         qs = qs[(page - 1) * limit:page * limit]
 
     if role := kwargs.get('role'):
-        qs = qs.filter('terms', categories=role)
+        filter_queries.append(Q('terms', categories=role))
 
     if client.extension_is_enabled('FilterExtension'):
 
@@ -197,4 +227,8 @@ def get_queryset(client, table: "Document" , **kwargs) -> Search:
         if not collection_ids:
             qs.aggs.bucket('collections', 'terms', field='collection_id.keyword')
 
+    qs = qs.query(Q('bool', must=[
+        Q('bool', should=should_queries),
+        Q('bool', filter=filter_queries)
+    ]))
     return qs

--- a/stac_fastapi/elasticsearch/utils.py
+++ b/stac_fastapi/elasticsearch/utils.py
@@ -231,8 +231,8 @@ def get_queryset(client, table: Document, **kwargs) -> Search:
         Q('bool', filter=filter_queries)
     ]))
 
-    # TODO: when fields extension is added, exchange this for kwargs.get('fields')
-    if source := kwargs.get('request').query_params.getlist(key='source'):
-        qs = qs.source(includes=source)
+    if client.extension_is_enabled('FieldsExtension'):
+        if fields := kwargs.get('fields'):
+            qs = qs.source(include=fields)
 
     return qs


### PR DESCRIPTION
# Implemented datetime search.

The query set construction has been refactored to use the `Q` method from the `elasticsearch_dsl.Search` library.

- single date:
  - this is transformed into a datetime range, see complete datetime query.
- single datetime query:
  - `properties.datetime == query` OR ( `properties.start_datetime <= query` AND `query <= properties.end_datetime` )
- complete datetime qeury: 
  - ( `properties.datetime >= query_start_datetime` AND `properties.datetime <= query_end_date` ) OR ( `properties.start_datetime >= query_start_datetime` AND `properties.end_datetime <= query_end_datetime` )
 - open ended datetimes queries:
   - open end date: `properties.datetime >= start` OR `properties.start_datetime >= start`
   - open start date: `properties.datetime <= end` OR `properties.end_datetime <= end`
   
Examples of this working, see section 14 of the [example notebook](https://github.com/cedadev/pystac-client/blob/54e37156196a394520c1398eda76a97ddf05c621/docs/tutorials/pystac-client-example.ipynb)

# Updated bbox search.

- `spatial_bbox` -> `spatial__bbox`
- Force bbox type to float (unsure why this changed to not automatically evaluate to number)
- Using Q constructor for the query

# Fields extension

Now filter what fields are returned on response.

Consider updating to a newer version of stac-fastAPI. The conformance uri for the Context and Fields extension have a typo:

[Old version](https://github.com/stac-utils/stac-fastapi/blob/7a97d6cac4764eacff3fb37aab3b9497dfa3d1b7/stac_fastapi/extensions/stac_fastapi/extensions/core/fields/fields.py#L33): 
```py
factory=lambda: ["https://api.stacspec.org/v1.0.0-beta.4/item-search/#fields"]
```

[New version](https://github.com/stac-utils/stac-fastapi/blob/52438a12a11554c4cbb782e3577d953170f7e142/stac_fastapi/extensions/stac_fastapi/extensions/core/fields/fields.py#L33)
```py
factory=lambda: ["https://api.stacspec.org/v1.0.0-rc.1/item-search#fields"]
```

This effects the conformance check on PySTAC but the fork I have changed it to recognise the old uri.